### PR TITLE
Adding validation for reversed datatypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,7 @@ The **S7 In** node makes the variable's values available in a flow in three diff
 
 ### Variable addressing
 
-The variables and their addresses configured on the **S7 Endpoint** follow a slightly different scheme than used on Step 7 or TIA Portal. 
-
-The default endianness is **Big-Endian**, but the address can be "reversed" as well, so we can interpret them as **Little-Endian**. The "reversed" type are only supported for WORD, DWORD, INT, DINT and REAL.
-
-Here are some examples that may guide you on addressing your variables:
+The variables and their addresses configured on the **S7 Endpoint** follow a slightly different scheme than used on Step 7 or TIA Portal. Here are some examples that may guide you on addressing your variables:
 
 | Address                       | Step7 equivalent      | JS Data type  | Description |
 | ----------------------------- | --------------------- | ------------- | ----------- |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ The **S7 In** node makes the variable's values available in a flow in three diff
 
 ### Variable addressing
 
-The variables and their addresses configured on the **S7 Endpoint** follow a slightly different scheme than used on Step 7 or TIA Portal. Here are some examples that may guide you on addressing your variables:
+The variables and their addresses configured on the **S7 Endpoint** follow a slightly different scheme than used on Step 7 or TIA Portal. 
+
+The default endianness is **Big-Endian**, but the address can be "reversed" as well, so we can interpret them as **Little-Endian**. The "reversed" type are only supported for WORD, DWORD, INT, DINT and REAL.
+
+Here are some examples that may guide you on addressing your variables:
 
 | Address                       | Step7 equivalent      | JS Data type  | Description |
 | ----------------------------- | --------------------- | ------------- | ----------- |
@@ -69,6 +73,9 @@ The variables and their addresses configured on the **S7 Endpoint** follow a sli
 | `DB1,DTZ10`                   | -                     | Date**        | A timestamp in the DATE_AND_TIME format, in UTC |
 | `DB2,DTL2`                    | -                     | Date**        | A timestamp in the DTL format |
 | `DB2,DTLZ12`                  | -                     | Date**        | A timestamp in the DTL format, in UTC |
+| `DB57,RWORD4`                 | `DB57.DBW4`           | Number        | Unsigned 16-bit number at byte 4 of DB 57, interpreted as Little-Endian |
+| `DB13,RDI5` or `DB13,RDINT5`  | `DB13.DBD5`           | Number        | Signed 32-bit number at byte 5 of DB 13, interpreted as Little-Endian |
+| `MRW20`                       | `MW20`                | Number        | Unsigned 16-bit number at byte 20 of memory area, interpreted as Little-Endian |
 
 
  - *) Note that strings on the PLC uses 2 extra bytes at start for size/length of the string

--- a/red/s7.html
+++ b/red/s7.html
@@ -162,6 +162,11 @@
 	<p>
 		The variables and their addresses configured on the <strong>S7 Endpoint</strong> 
 		follow a slightly different scheme than used on Step 7 or TIA Portal. 
+	</p>
+	<p>
+		The default endianness is <strong>Big-Endian</strong>, but the address can be "reversed" as well, 
+		so we can interpret them as <strong>Little-Endian</strong>.
+		The "reversed" type are only supported for WORD, DWORD, INT, DINT and REAL.
 		Here are some examples that may guide you on addressing your variables:
 	</p>
 	<style>
@@ -422,6 +427,24 @@
 				<td>Date**</td>
 				<td>A timestamp in the DTL format, in UTC</td>
 			</tr>
+			<tr>
+				<td><code>DB57,RWORD4</code></td>
+				<td><code>DB57.DBW4</code></td>
+				<td>Number</td>
+				<td>Unsigned 16-bit number at byte 4 of DB 57, interpreted as Little-Endian</td>
+			</tr>
+			<tr>
+				<td><code>DB13,RDI5</code> or <code>DB13,RDINT5</code></td>
+				<td><code>DB13.DBD5</code></td>
+				<td>Number</td>
+				<td>Signed 32-bit number at byte 5 of DB 13, interpreted as Little-Endian</td>
+			</tr>
+			<tr>
+				<td><code>MRW20</code></td>
+				<td><code>MRW20</code></td>
+				<td>Number</td>
+				<td>Unsigned 16-bit number at byte 20 of memory area, interpreted as Little-Endian</td>
+			</tr>
 		</tbody>
 	</table>
 
@@ -442,7 +465,7 @@
 
 		var NODES7_REGEX_ADDR = /^(?:DB(\d+),)?([A-Z]+)(\d+)(?:\.(\d+))?(?:\.(\d+))?$/;
 		var NODES7_ADDRTYPE = ["E", "I", "A", "Q", "P", "M", "T", "C"];
-		var NODES7_DATATYPE = ["X", "B", "C", "I", "DI", "W", "D", "DW", "R", "RI", "RDI", "RW", "R", "RDW", "RR"];
+		var NODES7_DATATYPE = ["X", "B", "C", "I", "DI", "W", "D", "DW", "R", "RI", "RDI", "RW", "RD", "RDW", "RR"];
 		var NODES7_DATATYPE_DB = ["X", "BYTE", "CHAR", "STRING", "INT", "DINT", "WORD", "DWORD", "REAL", "RINT", "RDINT", "RWORD", "RDWORD", "RREAL", "DT", "DTZ", "DTL", "DTLZ", "B", "C", "S", "I", "DI", "W", "D", "DW", "R", "RI", "RDI", "RW", "RD", "RDW", "RR"];
 
 		var match = address.match(NODES7_REGEX_ADDR);

--- a/red/s7.html
+++ b/red/s7.html
@@ -442,8 +442,8 @@
 
 		var NODES7_REGEX_ADDR = /^(?:DB(\d+),)?([A-Z]+)(\d+)(?:\.(\d+))?(?:\.(\d+))?$/;
 		var NODES7_ADDRTYPE = ["E", "I", "A", "Q", "P", "M", "T", "C"];
-		var NODES7_DATATYPE = ["X", "B", "C", "I", "DI", "W", "D", "DW", "R"];
-		var NODES7_DATATYPE_DB = ["X", "BYTE", "CHAR", "STRING", "INT", "DINT", "WORD", "DWORD", "REAL", "DT", "DTZ", "DTL", "DTLZ", "B", "C", "S", "I", "DI", "W", "D", "DW", "R"];
+		var NODES7_DATATYPE = ["X", "B", "C", "I", "DI", "W", "D", "DW", "R", "RI", "RDI", "RW", "RDW", "RR"];
+		var NODES7_DATATYPE_DB = ["X", "BYTE", "CHAR", "STRING", "INT", "DINT", "WORD", "DWORD", "REAL", "RINT", "RDINT", "RWORD", "RDWORD", "RREAL", "DT", "DTZ", "DTL", "DTLZ", "B", "C", "S", "I", "DI", "W", "D", "DW", "R", "RI", "RDI", "RW", "RD", "RDW", "RR"];
 
 		var match = address.match(NODES7_REGEX_ADDR);
 		if (!match) return 'ERR_PARSE_UNKNOWN_FORMAT';

--- a/red/s7.html
+++ b/red/s7.html
@@ -442,7 +442,7 @@
 
 		var NODES7_REGEX_ADDR = /^(?:DB(\d+),)?([A-Z]+)(\d+)(?:\.(\d+))?(?:\.(\d+))?$/;
 		var NODES7_ADDRTYPE = ["E", "I", "A", "Q", "P", "M", "T", "C"];
-		var NODES7_DATATYPE = ["X", "B", "C", "I", "DI", "W", "D", "DW", "R", "RI", "RDI", "RW", "RDW", "RR"];
+		var NODES7_DATATYPE = ["X", "B", "C", "I", "DI", "W", "D", "DW", "R", "RI", "RDI", "RW", "R", "RDW", "RR"];
 		var NODES7_DATATYPE_DB = ["X", "BYTE", "CHAR", "STRING", "INT", "DINT", "WORD", "DWORD", "REAL", "RINT", "RDINT", "RWORD", "RDWORD", "RREAL", "DT", "DTZ", "DTL", "DTLZ", "B", "C", "S", "I", "DI", "W", "D", "DW", "R", "RI", "RDI", "RW", "RD", "RDW", "RR"];
 
 		var match = address.match(NODES7_REGEX_ADDR);

--- a/red/s7.html
+++ b/red/s7.html
@@ -161,12 +161,7 @@
 	<h3>Variable addressing</h3>
 	<p>
 		The variables and their addresses configured on the <strong>S7 Endpoint</strong> 
-		follow a slightly different scheme than used on Step 7 or TIA Portal. 
-	</p>
-	<p>
-		The default endianness is <strong>Big-Endian</strong>, but the address can be "reversed" as well, 
-		so we can interpret them as <strong>Little-Endian</strong>.
-		The "reversed" type are only supported for WORD, DWORD, INT, DINT and REAL.
+		follow a slightly different scheme than used on Step 7 or TIA Portal.
 		Here are some examples that may guide you on addressing your variables:
 	</p>
 	<style>


### PR DESCRIPTION
Based on the pull request made in node s7 library [(addding_little_endian),](https://github.com/st-one-io/nodes7/pull/7) to support reversed datatypes, i'm adding a validation for those datatype in the node-red as well.